### PR TITLE
chore: reduce bundle size use for js files

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -115,7 +115,7 @@ mod tests {
       u2.clone(),
       ModuleInfo::Source(ModuleSource {
         source: "source".to_string(),
-        transpiled: "transpiled".to_string(),
+        transpiled: Some("transpiled".to_string()),
         deps: Vec::new(),
         content_type: None,
       }),
@@ -123,10 +123,12 @@ mod tests {
     let (final_url, module_source) = g.get_redirect(&u1).unwrap();
     assert_eq!(final_url, u2);
     assert_eq!(module_source.source, "source");
+    assert_eq!(module_source.get_code(), "transpiled");
 
     let (final_url, module_source) = g.get_redirect(&u2).unwrap();
     assert_eq!(final_url, u2);
     assert_eq!(module_source.source, "source");
+    assert_eq!(module_source.get_code(), "transpiled");
 
     assert!(g.get_redirect(&u3).is_none());
   }

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -39,9 +39,18 @@ type ModuleInfoFuture =
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ModuleSource {
   pub source: String,
-  pub transpiled: String,
+  pub transpiled: Option<String>,
   pub content_type: Option<String>,
   pub deps: Vec<Url>,
+}
+
+impl ModuleSource {
+  pub fn get_code(&self) -> String {
+    self
+      .transpiled
+      .clone()
+      .unwrap_or_else(|| self.source.clone())
+  }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
This commit changes how pure JS files are stored in the bundle. They are
no longer transpiled. Instead the `transpiled` field is now an `Option`,
and for JS files this `Option` is `None`. After the change old zips will
work with the new loader, but the old loader will not work with new
zips.
