### PR TITLE
feat: support data URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-url"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d33fe99ccedd6e84bc035f1931bb2e6be79739d6242bd895e7311c886c50dc9c"
+dependencies = [
+ "matches",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +224,7 @@ name = "eszip"
 version = "0.8.0"
 dependencies = [
  "base64 0.13.0",
+ "data-url",
  "futures",
  "indicatif",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ swc_ecmascript = { version = "0.31", features = ["codegen", "dep_graph","parser"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }
 url = { version = "2", features = ["serde"] }
+data-url = "0.1.0"
 
 [dev-dependencies]
 indicatif = "0.15"

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,8 @@ pub enum Error {
   Other(Box<dyn std::error::Error + Sync + Send + 'static>),
   #[error("invalid data url '{specifier}': '{error}'")]
   InvalidDataUrl { specifier: String, error: String },
+  #[error("scheme '{scheme}' is not supported: '{specifier}'")]
+  InvalidScheme { scheme: String, specifier: String },
 }
 
 pub fn reqwest_error(specifier: String, error: reqwest::Error) -> Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,8 @@ pub enum Error {
   },
   #[error(transparent)]
   Other(Box<dyn std::error::Error + Sync + Send + 'static>),
+  #[error("invalid data url '{specifier}': '{error}'")]
+  InvalidDataUrl { specifier: String, error: String },
 }
 
 pub fn reqwest_error(specifier: String, error: reqwest::Error) -> Error {

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,5 +1,6 @@
 use crate::error::Error;
 use crate::parser::get_deps_and_transpile;
+use data_url::DataUrl;
 use futures::stream::FuturesUnordered;
 use futures::task::Poll;
 use futures::Stream;
@@ -65,6 +66,39 @@ pub struct ModuleStream<L: ModuleLoader> {
   loader: L,
 }
 
+fn load_data_url(url: Url) -> Result<(Url, ModuleInfo), Error> {
+  let data_url = DataUrl::process(url.as_str()).map_err(|e| {
+    Error::InvalidDataUrl {
+      specifier: url.to_string(),
+      error: format!("{:?}", e),
+    }
+  })?;
+  let (body, _) = data_url.decode_to_vec().map_err(|e| {
+    Error::InvalidDataUrl {
+      specifier: url.to_string(),
+      error: format!("{:?}", e),
+    }
+  })?;
+  let source = String::from_utf8(body).map_err(|e| {
+    Error::InvalidDataUrl {
+      specifier: url.to_string(),
+      error: format!("{:?}", e),
+    }
+  })?;
+  let content_type = Some(data_url.mime_type().to_string());
+  let (deps, transpiled) =
+    get_deps_and_transpile(&url, &source, &content_type)?;
+  Ok((
+    url,
+    ModuleInfo::Source(ModuleSource {
+      source,
+      content_type,
+      deps,
+      transpiled,
+    }),
+  ))
+}
+
 impl<L: ModuleLoader> ModuleStream<L> {
   pub fn new(root: Url, loader: L) -> Self {
     let mut g = Self {
@@ -83,28 +117,34 @@ impl<L: ModuleLoader> ModuleStream<L> {
   fn append_module(&mut self, url: Url) {
     if !self.started.contains(&url) {
       self.started.insert(url.clone());
-      let url_ = url.clone();
-      let fut =
-        Box::pin(self.loader.load(url).and_then(|module_source| async move {
-          let module_info = match module_source {
-            ModuleLoad::Redirect(url) => ModuleInfo::Redirect(url),
-            ModuleLoad::Source {
-              source,
-              content_type,
-            } => {
-              let (deps, transpiled) =
-                get_deps_and_transpile(&url_, &source, &content_type)?;
-              ModuleInfo::Source(ModuleSource {
+      if url.scheme() == "data" {
+        self
+          .pending
+          .push(Box::pin(futures::future::ready(load_data_url(url))));
+      } else {
+        let fut = Box::pin(self.loader.load(url.clone()).and_then(
+          |module_source| async move {
+            let module_info = match module_source {
+              ModuleLoad::Redirect(url) => ModuleInfo::Redirect(url),
+              ModuleLoad::Source {
                 source,
-                transpiled,
                 content_type,
-                deps,
-              })
-            }
-          };
-          Ok((url_, module_info))
-        }));
-      self.pending.push(fut);
+              } => {
+                let (deps, transpiled) =
+                  get_deps_and_transpile(&url, &source, &content_type)?;
+                ModuleInfo::Source(ModuleSource {
+                  source,
+                  transpiled,
+                  content_type,
+                  deps,
+                })
+              }
+            };
+            Ok((url, module_info))
+          },
+        ));
+        self.pending.push(fut);
+      }
     }
   }
 }
@@ -205,6 +245,31 @@ mod tests {
     let r = Pin::new(&mut stream).poll_next(&mut cx);
     if let Poll::Ready(None) = r {
       // expected
+    } else {
+      panic!("unexpected");
+    }
+  }
+
+
+  #[test]
+  fn data_url() {
+    let root = Url::parse("data:text/javascript;base64,Y29uc29sZS5sb2coJ2hpJyk7").unwrap();
+    let mut stream = ModuleStream::new(root.clone(), MemoryLoader(HashMap::new()));
+    assert_eq!(stream.total(), 1);
+
+    let mut cx =
+      std::task::Context::from_waker(futures::task::noop_waker_ref());
+
+    let r = Pin::new(&mut stream).poll_next(&mut cx);
+    if let Poll::Ready(Some(Ok((url, module_info)))) = r {
+      assert_eq!(url.as_str(), "data:text/javascript;base64,Y29uc29sZS5sb2coJ2hpJyk7");
+      if let ModuleInfo::Source(module_source) = module_info {
+        assert_eq!(module_source.deps.len(), 0);
+        println!("{:?}", module_source);
+        assert!(module_source.source.contains("console.log('hi')"));
+      } else {
+        unreachable!()
+      }
     } else {
       panic!("unexpected");
     }

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -67,23 +67,21 @@ pub struct ModuleStream<L: ModuleLoader> {
 }
 
 fn load_data_url(url: Url) -> Result<(Url, ModuleInfo), Error> {
-  let data_url = DataUrl::process(url.as_str()).map_err(|e| {
-    Error::InvalidDataUrl {
+  let data_url =
+    DataUrl::process(url.as_str()).map_err(|e| Error::InvalidDataUrl {
       specifier: url.to_string(),
       error: format!("{:?}", e),
-    }
-  })?;
-  let (body, _) = data_url.decode_to_vec().map_err(|e| {
-    Error::InvalidDataUrl {
-      specifier: url.to_string(),
-      error: format!("{:?}", e),
-    }
-  })?;
-  let source = String::from_utf8(body).map_err(|e| {
-    Error::InvalidDataUrl {
-      specifier: url.to_string(),
-      error: format!("{:?}", e),
-    }
+    })?;
+  let (body, _) =
+    data_url
+      .decode_to_vec()
+      .map_err(|e| Error::InvalidDataUrl {
+        specifier: url.to_string(),
+        error: format!("{:?}", e),
+      })?;
+  let source = String::from_utf8(body).map_err(|e| Error::InvalidDataUrl {
+    specifier: url.to_string(),
+    error: format!("{:?}", e),
   })?;
   let content_type = Some(data_url.mime_type().to_string());
   let (deps, transpiled) =
@@ -250,11 +248,13 @@ mod tests {
     }
   }
 
-
   #[test]
   fn data_url() {
-    let root = Url::parse("data:text/javascript;base64,Y29uc29sZS5sb2coJ2hpJyk7").unwrap();
-    let mut stream = ModuleStream::new(root.clone(), MemoryLoader(HashMap::new()));
+    let root =
+      Url::parse("data:text/javascript;base64,Y29uc29sZS5sb2coJ2hpJyk7")
+        .unwrap();
+    let mut stream =
+      ModuleStream::new(root.clone(), MemoryLoader(HashMap::new()));
     assert_eq!(stream.total(), 1);
 
     let mut cx =
@@ -262,10 +262,12 @@ mod tests {
 
     let r = Pin::new(&mut stream).poll_next(&mut cx);
     if let Poll::Ready(Some(Ok((url, module_info)))) = r {
-      assert_eq!(url.as_str(), "data:text/javascript;base64,Y29uc29sZS5sb2coJ2hpJyk7");
+      assert_eq!(
+        url.as_str(),
+        "data:text/javascript;base64,Y29uc29sZS5sb2coJ2hpJyk7"
+      );
       if let ModuleInfo::Source(module_source) = module_info {
         assert_eq!(module_source.deps.len(), 0);
-        println!("{:?}", module_source);
         assert!(module_source.source.contains("console.log('hi')"));
       } else {
         unreachable!()


### PR DESCRIPTION
This PR introduces data URL support.
```
➜  cargo run --example fetch data:text/javascript\;base64,Y29uc29sZS5sb2coJ2hpJyk7
    Finished dev [unoptimized + debuginfo] target(s) in 0.13s
     Running `target/debug/examples/fetch 'data:text/javascript;base64,Y29uc29sZS5sb2coJ2hpJyk7'`
  1/1   data:text/javascript;base64,Y29uc29sZS5sb2coJ2hpJyk7
{
  "version": 1,
  "modules": {
    "data:text/javascript;base64,Y29uc29sZS5sb2coJ2hpJyk7": {
      "Source": {
        "source": "console.log('hi');",
        "transpiled": null,
        "content_type": "text/javascript",
        "deps": []
      }
    }
  }
}
```
It also introduces changes to an error on unsupported schemes like `file:`.