### PR TITLE
feat: store source maps out of band

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,6 @@ dependencies = [
 name = "eszip"
 version = "0.13.0"
 dependencies = [
- "base64 0.13.0",
  "data-url",
  "deno_ast",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ name = "eszip"
 path = "src/lib.rs"
 
 [dependencies]
-base64 = "0.13"
 deno_ast = { version = "0.2", features = ["codegen", "dep_graph", "proposal", "react", "sourcemap", "transforms", "typescript", "visit"] }
 futures = "0.3"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -92,6 +92,7 @@ impl DerefMut for ModuleGraph {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::parser::FauxSourceMap;
 
   #[test]
   fn is_complete() {
@@ -110,12 +111,20 @@ mod tests {
     let u2 = Url::parse("http://deno.land/u2.js").unwrap();
     let u3 = Url::parse("http://deno.land/u3.js").unwrap();
 
+    let source_map = FauxSourceMap {
+      version: 3,
+      sources: vec![],
+      names: vec![],
+      mappings: String::new(),
+    };
+
     g.insert(u1.clone(), ModuleInfo::Redirect(u2.clone()));
     g.insert(
       u2.clone(),
       ModuleInfo::Source(ModuleSource {
         source: "source".to_string(),
         transpiled: Some("transpiled".to_string()),
+        source_map: Some(source_map),
         deps: Vec::new(),
         content_type: None,
       }),


### PR DESCRIPTION
Don't store source maps inline. It bloats the transpiled file size by
100% or more and it prevents clever optimizations in Deploy.

<hr>

To support streaming parsing in Deploy, ideally source _files_ are at the start of the archive and source _maps_ at the end.