### PR TITLE
feat: first iteration of an eszip CLI

### DIFF
--- a/lib/eszip.ts
+++ b/lib/eszip.ts
@@ -1,0 +1,174 @@
+#!/usr/bin/env -S deno run --allow-run=deno --allow-read --allow-write --allow-net=deno.land --no-check
+
+/**
+ * CLI utility to list/extract/run ESZIPs
+ */
+
+import { Parser } from "./mod.ts";
+import { dirname, join } from "https://deno.land/std@0.127.0/path/mod.ts";
+import { assertStrictEquals } from "https://deno.land/std@0.127.0/testing/asserts.ts";
+
+function hasV2Header(bytes: Uint8Array) {
+  const magicV2 = new TextDecoder().decode(bytes.slice(0, 8));
+  return magicV2 === "ESZIP_V2";
+}
+
+interface ESZIP {
+  extract(dest: string): Promise<void>;
+  list(): string[];
+}
+
+interface V1Entry {
+  Source: {
+    source: string;
+    transpiled: string;
+  };
+}
+
+class V1 {
+  inner: Record<string, V1Entry>;
+
+  constructor(bytes: Uint8Array) {
+    const json = new TextDecoder().decode(bytes);
+    const eszip = JSON.parse(json);
+    assertStrictEquals(eszip.version, 1);
+    this.inner = eszip;
+  }
+
+  static load(bytes: Uint8Array) {
+    return Promise.resolve(new V1(bytes));
+  }
+
+  *entries() {
+    for (
+      const [
+        url,
+        {
+          Source: { source, transpiled },
+        },
+      ] of Object.entries(this.inner.modules)
+    ) {
+      yield { url, source, transpiled };
+    }
+  }
+
+  async extract(dest: string) {
+    for (const { url, source, transpiled } of this.entries()) {
+      await write(join(dest, "source", url2path(url)), source);
+      await write(
+        join(dest, "transpiled", url2path(url)),
+        transpiled ?? source,
+      );
+    }
+  }
+
+  list() {
+    return Array.from(this.entries()).map((e) => e.url);
+  }
+}
+
+class V2 {
+  parser: Parser;
+  specifiers: string[];
+
+  constructor(parser: Parser, specifiers: string[]) {
+    this.parser = parser;
+    this.specifiers = specifiers;
+  }
+
+  static async load(bytes: Uint8Array) {
+    const parser = new Parser();
+    const specifiers = await parser.parseBytes(bytes);
+    await parser.load();
+    return new V2(parser, specifiers as string[]);
+  }
+
+  async extract(dest: string) {
+    const imports: Record<string, string> = {};
+
+    for (const specifier of this.specifiers) {
+      const module = await this.parser.getModuleSource(specifier);
+      await write(join(dest, "source", url2path(specifier)), module);
+      // Track import
+      imports[specifier] = `./${url2path(specifier)}`;
+    }
+    // Write import map
+    const importMap = JSON.stringify({ imports }, null, 2);
+    await Deno.writeTextFile(
+      join(dest, "source", "import_map.json"),
+      importMap,
+    );
+  }
+
+  list() {
+    return this.specifiers;
+  }
+}
+
+async function loadESZIP(filename: string): Promise<ESZIP> {
+  const bytes = await Deno.readFile(filename);
+  if (hasV2Header(bytes)) {
+    console.log("Loading eszip v2");
+    return await V2.load(bytes);
+  }
+  console.log("Loading eszip v1");
+  return await V1.load(bytes);
+}
+
+function url2path(url: string) {
+  return join(...(new URL(url).pathname.split("/").filter(Boolean)));
+}
+
+async function write(path: string, content: string) {
+  await Deno.mkdir(dirname(path), { recursive: true });
+  await Deno.writeTextFile(path, content);
+}
+
+async function run(eszip: ESZIP, specifier: string) {
+  // Extract to tmp directory
+  const tmpDir = await Deno.makeTempDir({ prefix: "esz" });
+  try {
+    // Extract
+    await eszip.extract(tmpDir);
+    const importMap = join(tmpDir, "source", "import_map.json");
+    // Run
+    const p = Deno.run({
+      cmd: ["deno", "run", "-A", "--import-map", importMap, specifier],
+    });
+    await p.status();
+  } finally {
+    // Cleanup
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+}
+
+// Main
+async function main() {
+  const args = Deno.args;
+  const [subcmd, filename, ...rest] = args;
+
+  if (subcmd === "help") {
+    return console.log("TODO");
+  }
+
+  const eszip = await loadESZIP(filename);
+
+  switch (subcmd) {
+    case "x":
+    case "extract":
+      return await eszip.extract(rest[0] ?? Deno.cwd());
+    case "l":
+    case "ls":
+    case "list":
+      return console.log(eszip.list().join("\n"));
+    case "r":
+    case "run": {
+      const specifier = rest[0];
+      if (!specifier) {
+        return console.error("Please provide a specifier to run");
+      }
+      return await run(eszip, specifier);
+    }
+  }
+}
+await main();


### PR DESCRIPTION
A first pass at a small "swiss army knife" for ESZIPs with the following subcommands:
-`l`/`ls`/`list`: lists specifiers (without extracting)
-`x`/`extract`: extracts to a directory of the user's choice
-`r`/`run`: extracts to a tmp dir, runs `deno` with an import map then cleans up the tmp dir

## Future improvements

- Use `deno vendor` logic for more robust extraction
- Limit permissions of run
- Print out module graph/tree vs list
- Warn of dangling/missing specifiers
- Rewrite in Rust ? (easier to reuse vendoring, graph tooling, etc...)