### PR TITLE
tool: Add `eszip build` subcommand

### DIFF
--- a/lib/eszip.ts
+++ b/lib/eszip.ts
@@ -1,10 +1,8 @@
 #!/usr/bin/env -S deno run --allow-run=deno --allow-read --allow-write --allow-net=deno.land --no-check
 
-/**
- * CLI utility to list/extract/run ESZIPs
- */
+// CLI utility to list/extract/run ESZIPs
 
-import { Parser } from "./mod.ts";
+import { build, Parser } from "./mod.ts";
 import { dirname, join } from "https://deno.land/std@0.127.0/path/mod.ts";
 import { assertStrictEquals } from "https://deno.land/std@0.127.0/testing/asserts.ts";
 
@@ -133,7 +131,15 @@ async function run(eszip: ESZIP, specifier: string) {
     const importMap = join(tmpDir, "source", "import_map.json");
     // Run
     const p = Deno.run({
-      cmd: ["deno", "run", "-A", "--import-map", importMap, specifier],
+      cmd: [
+        "deno",
+        "run",
+        "-A",
+        "--no-check",
+        "--import-map",
+        importMap,
+        specifier,
+      ],
     });
     await p.status();
   } finally {
@@ -151,18 +157,30 @@ async function main() {
     return console.log("TODO");
   }
 
-  const eszip = await loadESZIP(filename);
-
   switch (subcmd) {
+    case "build":
+    case "b": {
+      const eszip = await build([filename, ...rest]);
+      // Create outfile name from url filename
+      const out = new URL(filename).pathname.split("/").pop();
+      console.log(`${out}.eszip: ${eszip.length} bytes`);
+      await Deno.writeFile(`${out}.eszip`, eszip);
+      return;
+    }
     case "x":
-    case "extract":
+    case "extract": {
+      const eszip = await loadESZIP(filename);
       return await eszip.extract(rest[0] ?? Deno.cwd());
+    }
     case "l":
     case "ls":
-    case "list":
+    case "list": {
+      const eszip = await loadESZIP(filename);
       return console.log(eszip.list().join("\n"));
+    }
     case "r":
     case "run": {
+      const eszip = await loadESZIP(filename);
       const specifier = rest[0];
       if (!specifier) {
         return console.error("Please provide a specifier to run");

--- a/lib/eszip.ts
+++ b/lib/eszip.ts
@@ -160,9 +160,12 @@ async function main() {
   switch (subcmd) {
     case "build":
     case "b": {
-      const eszip = await build([filename, ...rest]);
-      // Create outfile name from url filename
-      const out = new URL(filename).pathname.split("/").pop();
+      const eszip = await build([filename]);
+      let out = rest[0];
+      if (!out) {
+        // Create outfile name from url filename
+        out = new URL(filename).pathname.split("/").pop() || "out.eszip";
+      }
       console.log(`${out}.eszip: ${eszip.length} bytes`);
       await Deno.writeFile(`${out}.eszip`, eszip);
       return;

--- a/lib/eszip.ts
+++ b/lib/eszip.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S deno run --allow-run=deno --allow-read --allow-write --allow-net=deno.land --no-check
 
-// CLI utility to list/extract/run ESZIPs
+// CLI utility to build/list/extract/run ESZIPs
 
 import { build, Parser } from "./mod.ts";
 import { dirname, join } from "https://deno.land/std@0.127.0/path/mod.ts";

--- a/lib/eszip.ts
+++ b/lib/eszip.ts
@@ -164,7 +164,7 @@ async function main() {
       let out = rest[0];
       if (!out) {
         // Create outfile name from url filename
-        out = new URL(filename).pathname.split("/").pop() || "out.eszip";
+        out = new URL(filename).pathname.split("/").pop() || "out";
       }
       console.log(`${out}.eszip: ${eszip.length} bytes`);
       await Deno.writeFile(`${out}.eszip`, eszip);

--- a/lib/eszip_wasm.generated.js
+++ b/lib/eszip_wasm.generated.js
@@ -343,13 +343,11 @@ const imports = {
     __wbindgen_string_get: function (arg0, arg1) {
       const obj = getObject(arg1);
       var ret = typeof (obj) === "string" ? obj : undefined;
-      var ptr0 = isLikeNone(ret)
-        ? 0
-        : passStringToWasm0(
-          ret,
-          wasm.__wbindgen_malloc,
-          wasm.__wbindgen_realloc,
-        );
+      var ptr0 = isLikeNone(ret) ? 0 : passStringToWasm0(
+        ret,
+        wasm.__wbindgen_malloc,
+        wasm.__wbindgen_realloc,
+      );
       var len0 = WASM_VECTOR_LEN;
       getInt32Memory0()[arg0 / 4 + 1] = len0;
       getInt32Memory0()[arg0 / 4 + 0] = ptr0;


### PR DESCRIPTION
Also updates `eszip run` to use `--no-check` by default since the graph contains transpiled modules and type checking is pointless.