### PR TITLE
feat: Allow cloning an `EszipV2`

### DIFF
--- a/src/v2.rs
+++ b/src/v2.rs
@@ -1141,7 +1141,6 @@ mod tests {
 
   #[tokio::test]
   #[should_panic]
-  #[allow(unused_must_use)]
   async fn clone_fails_when_pending() {
     let file = std::fs::File::open("./src/testdata/redirect.eszip2").unwrap();
     let (eszip, _) =
@@ -1151,7 +1150,10 @@ mod tests {
     // We don't await for the future!
 
     // Panics
-    eszip.clone();
+    let cloned = eszip.clone();
+
+    // We do this to avoid an redundant clone or unused value lint.
+    let _ = (eszip, cloned);
   }
 
   #[tokio::test]


### PR DESCRIPTION
This patch adds a `Clone` implementation for `EszipV2`. Since this struct can transitively contain `Waker`s, which are not clonable, this implementation will panic if some source slot is still pending parsing.

One issue is that the modules map of `EszipV2` is behind an `Arc<Mutex>`, and therefore directly cloning it (with `#[derive(Clone)]`, for example) would leave the clone "connected" to the original, and able to change through `EszipV2::add_import_map`. Therefore, it instead uses a custom `Clone` implementation that copies the contents of the module map to prevent this.
