### PR TITLE
fix: avoid including duplicate import map if it's imported from program

### DIFF
--- a/src/testdata/source/import_import_map.js
+++ b/src/testdata/source/import_import_map.js
@@ -1,0 +1,1 @@
+import m from "./import_map.json" assert { type: "json" };

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -344,10 +344,17 @@ impl EszipV2 {
     }
     let mut module_ordering =
       Vec::with_capacity(self.ordered_modules.len() + 1);
-    module_ordering.push(specifier);
+    module_ordering.push(specifier.clone());
     let old_module_ordering =
       std::mem::replace(&mut self.ordered_modules, module_ordering);
-    self.ordered_modules.extend_from_slice(&old_module_ordering);
+    // `old_module_ordering` might contain the same module as the import map
+    // that the given `specifier specifies. To avoid having duplicate module, we
+    // check and exclude that from `old_module_ordering`.
+    let old_module_ordering_without_import_map =
+      old_module_ordering.into_iter().filter(|x| x != &specifier);
+    self
+      .ordered_modules
+      .extend(old_module_ordering_without_import_map);
   }
 
   /// Serialize the eszip archive into a byte buffer.

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -1087,6 +1087,7 @@ mod tests {
     assert_eq!(module.kind, ModuleKind::JavaScript);
   }
 
+  // https://github.com/denoland/eszip/issues/110
   #[tokio::test]
   async fn import_map_imported_from_program() {
     let mut loader = FileLoader;

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -348,8 +348,8 @@ impl EszipV2 {
     let old_module_ordering =
       std::mem::replace(&mut self.ordered_modules, module_ordering);
     // `old_module_ordering` might contain the same module as the import map
-    // that the given `specifier specifies. To avoid having duplicate module, we
-    // check and exclude that from `old_module_ordering`.
+    // that the given `specifier` specifies. To avoid having duplicate module,
+    // we check and exclude that from `old_module_ordering`.
     let old_module_ordering_without_import_map =
       old_module_ordering.into_iter().filter(|x| x != &specifier);
     self


### PR DESCRIPTION
This commit ensures that one import map appears just once in the generated eszip.

Fixes #110 

Now a generated eszip works fine with eszip_builder and eszip_viewer.

### eszip_builder

```sh
$ cargo run --example eszip_builder file://$(pwd)/main.js out.eszip file://$(pwd)/import_map.json
source: file:///Users/yusuktan/Repo/github.com/magurotuna/eszip/import_map.json
source: file:///Users/yusuktan/Repo/github.com/magurotuna/eszip/main.js
```

### eszip_viewer

```sh
$ cargo run --example eszip_viewer out.eszip
Specifier: file:///Users/yusuktan/Repo/github.com/magurotuna/eszip/import_map.json
Kind: Json
---
{
  "imports": {
  }
}

---

============
Specifier: file:///Users/yusuktan/Repo/github.com/magurotuna/eszip/main.js
Kind: JavaScript
---
import m from "./import_map.json" assert { type: "json" };

---

============
```
