### PR TITLE
fix: don't fail build on dynamic import load error

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.68.0"
+channel = "1.68.2"
 components = ["clippy", "rustfmt"]

--- a/src/testdata/emit/dynamic.ts
+++ b/src/testdata/emit/dynamic.ts
@@ -3,3 +3,5 @@ const { default: data  } = await import("./data.json", {
         type: "json"
     }
 });
+await import("./relative_doesnt_exist.ts");
+await import("not_real");

--- a/src/testdata/source/dynamic.ts
+++ b/src/testdata/source/dynamic.ts
@@ -1,3 +1,5 @@
 const { default: data } = await import("./data.json", {
   assert: { type: "json" },
 });
+await import("./relative_doesnt_exist.ts");
+await import("not_real");


### PR DESCRIPTION
This commit fixes a case where dynamically importing a specifier that
resolves, but does not load (ie a relative specifier pointing to
nowhere), would cause the EszipV2::from_graph process to fail.

This commit fixes this behaviour by ignoring load errors for modules
only imported via dynamic import.
