### PR TITLE
fix: build graph with `GraphKind::Code` and validate the ModuleGraph when creating an eszip

### DIFF
--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -4,6 +4,7 @@ use deno_graph::source::LoadFuture;
 use deno_graph::source::Loader;
 use deno_graph::source::Resolver;
 use deno_graph::BuildOptions;
+use deno_graph::GraphKind;
 use deno_graph::ModuleGraph;
 use deno_graph::ModuleSpecifier;
 use eszip::v2::Url;
@@ -282,7 +283,7 @@ pub async fn build_eszip(
     };
   let resolver = GraphResolver(maybe_import_map);
   let analyzer = deno_graph::CapturingModuleAnalyzer::default();
-  let mut graph = ModuleGraph::default();
+  let mut graph = ModuleGraph::new(GraphKind::CodeOnly);
   graph
     .build(
       roots,
@@ -294,9 +295,6 @@ pub async fn build_eszip(
       },
     )
     .await;
-  graph
-    .valid()
-    .map_err(|e| js_sys::Error::new(&e.to_string()))?;
   let mut eszip = eszip::EszipV2::from_graph(
     graph,
     &analyzer.as_capturing_parser(),

--- a/src/examples/builder.rs
+++ b/src/examples/builder.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use deno_ast::EmitOptions;
 use deno_graph::BuildOptions;
 use deno_graph::CapturingModuleAnalyzer;
+use deno_graph::GraphKind;
 use deno_graph::ModuleGraph;
 use import_map::ImportMap;
 use reqwest::StatusCode;
@@ -41,7 +42,7 @@ async fn main() {
 
   let analyzer = CapturingModuleAnalyzer::default();
 
-  let mut graph = ModuleGraph::default();
+  let mut graph = ModuleGraph::new(GraphKind::CodeOnly);
   graph
     .build(
       vec![url],
@@ -53,8 +54,6 @@ async fn main() {
       },
     )
     .await;
-
-  graph.valid().unwrap();
 
   let mut eszip = eszip::EszipV2::from_graph(
     graph,


### PR DESCRIPTION
Need to add tests still.