### PR TITLE
refactor: use LinkedHashMap to maintain the order of modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,7 @@ dependencies = [
  "deno_ast",
  "deno_graph",
  "futures",
+ "hashlink",
  "import_map",
  "pretty_assertions",
  "reqwest",
@@ -542,6 +543,18 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ base64 = "0.21.0"
 deno_ast = { version = "0.26.0", features = ["transpiling"] }
 deno_graph = "0.48.0"
 futures = "0.3.26"
+hashlink = "0.8.1"
 serde = "1"
 serde_json = "1"
 sha2 = "0.10.1"

--- a/src/examples/builder.rs
+++ b/src/examples/builder.rs
@@ -70,7 +70,7 @@ async fn main() {
       Arc::new(import_map_content.as_bytes().to_vec()),
     )
   }
-  for specifier in &eszip.ordered_modules {
+  for specifier in eszip.specifiers() {
     println!("source: {specifier}")
   }
 

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -37,7 +37,7 @@ enum HeaderFrameKind {
 #[derive(Debug, Default)]
 pub struct EszipV2 {
   modules: Arc<Mutex<HashMap<String, EszipV2Module>>>,
-  pub ordered_modules: Vec<String>,
+  ordered_modules: Vec<String>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This commit makes use of `LinkedHashMap` to maintain the insertion order of modules, instead of manually combining `HashMap` and `Vec`. This reduces much code without breaking any existing behavior.