### PR TITLE
feat: allow JSONC to be embedded as an import map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,7 @@ dependencies = [
  "deno_ast",
  "deno_graph",
  "futures",
+ "hashlink",
  "import_map",
  "pretty_assertions",
  "reqwest",
@@ -542,6 +543,18 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,6 +331,7 @@ dependencies = [
  "futures",
  "hashlink",
  "import_map",
+ "jsonc-parser",
  "pretty_assertions",
  "reqwest",
  "serde",
@@ -731,6 +732,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonc-parser"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b56a20e76235284255a09fcd1f45cf55d3c524ea657ebd3854735925c57743d"
+dependencies = [
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ base64 = "0.21.0"
 deno_ast = { version = "0.26.0", features = ["transpiling"] }
 deno_graph = "0.48.0"
 futures = "0.3.26"
+hashlink = "0.8.1"
 serde = "1"
 serde_json = "1"
 sha2 = "0.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,4 @@ import_map = "0.15.0"
 pretty_assertions = "1"
 tokio = { version = "1", features = ["macros", "rt"] }
 reqwest = { version = "0.11", features = ["rustls-tls"] }
+jsonc-parser = { version = "0.21.1", features = ["serde"] }

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -7,6 +7,7 @@ use deno_graph::BuildOptions;
 use deno_graph::ModuleGraph;
 use deno_graph::ModuleSpecifier;
 use eszip::v2::Url;
+use eszip::ModuleKind;
 use futures::io::AsyncRead;
 use futures::io::BufReader;
 use import_map::ImportMap;
@@ -307,6 +308,7 @@ pub async fn build_eszip(
     maybe_import_map_data
   {
     eszip.add_import_map(
+      ModuleKind::Json,
       import_map_specifier.to_string(),
       Arc::new(import_map_content.as_bytes().to_vec()),
     )

--- a/src/examples/builder.rs
+++ b/src/examples/builder.rs
@@ -70,7 +70,7 @@ async fn main() {
       Arc::new(import_map_content.as_bytes().to_vec()),
     )
   }
-  for specifier in &eszip.ordered_modules {
+  for specifier in eszip.specifiers() {
     println!("source: {specifier}")
   }
 

--- a/src/examples/builder.rs
+++ b/src/examples/builder.rs
@@ -66,6 +66,7 @@ async fn main() {
     maybe_import_map_data
   {
     eszip.add_import_map(
+      eszip::ModuleKind::Json,
       import_map_specifier.to_string(),
       Arc::new(import_map_content.as_bytes().to_vec()),
     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,13 @@ impl Eszip {
       Eszip::V2(eszip) => eszip.get_module(specifier),
     }
   }
+
+  pub fn get_import_map(&self, specifier: &str) -> Option<Module> {
+    match self {
+      Eszip::V1(eszip) => eszip.get_import_map(specifier),
+      Eszip::V2(eszip) => eszip.get_import_map(specifier),
+    }
+  }
 }
 
 pub struct Module {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,14 +117,18 @@ impl Module {
 }
 
 /// This is the kind of module that is being stored. This is the same enum as is
-/// present in [deno_core], but because we can not depend on that crate, this
-/// is a copy of that definition.
+/// present in [deno_core::ModuleType] except that this has additional variant
+/// `Jsonc` which is used when an import map is embedded in Deno's config file
+/// that can be JSONC.
+/// Note that a module of type `Jsonc` can be used only as an import map, not as
+/// a normal module.
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum ModuleKind {
   JavaScript = 0,
   Json = 1,
+  Jsonc = 2,
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,13 @@ impl Eszip {
     }
   }
 
+  /// Get the module metadata for a given module specifier. This function will
+  /// follow redirects. The returned module has functions that can be used to
+  /// obtain the module source and source map. The module returned from this
+  /// function is guaranteed to be a valid module, which can be loaded into v8.
+  ///
+  /// Note that this function should be used to obtain a module; if you wish to
+  /// get an import map, use [`get_import_map`](Self::get_import_map) instead.
   pub fn get_module(&self, specifier: &str) -> Option<Module> {
     match self {
       Eszip::V1(eszip) => eszip.get_module(specifier),
@@ -58,6 +65,12 @@ impl Eszip {
     }
   }
 
+  /// Get the import map for a given specifier.
+  ///
+  /// Note that this function should be used to obtain an import map; the returned
+  /// "Module" is not necessarily a valid module that can be loaded into v8 (in
+  /// other words, JSONC may be returned). If you wish to get a valid module,
+  /// use [`get_module`](Self::get_module) instead.
   pub fn get_import_map(&self, specifier: &str) -> Option<Module> {
     match self {
       Eszip::V1(eszip) => eszip.get_import_map(specifier),

--- a/src/testdata/deno_jsonc_as_import_map/a.ts
+++ b/src/testdata/deno_jsonc_as_import_map/a.ts
@@ -1,0 +1,1 @@
+export const b = "b";

--- a/src/testdata/deno_jsonc_as_import_map/deno.jsonc
+++ b/src/testdata/deno_jsonc_as_import_map/deno.jsonc
@@ -1,0 +1,9 @@
+{
+  "tasks": {
+    "run": "deno run main.ts"
+  },
+  // comment
+  "imports": {
+    "a": "./a.ts"
+  }
+}

--- a/src/testdata/deno_jsonc_as_import_map/main.ts
+++ b/src/testdata/deno_jsonc_as_import_map/main.ts
@@ -1,0 +1,1 @@
+export * as a from "./a.ts";

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -70,6 +70,12 @@ impl EszipV1 {
     }
   }
 
+  pub fn get_import_map(&self, _specifier: &str) -> Option<Module> {
+    // V1 never contains an import map in it. This method exists to make it
+    // consistent with V2's interface.
+    None
+  }
+
   /// Get source code of the module.
   pub(crate) fn get_module_source(
     &self,

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -1195,7 +1195,11 @@ mod tests {
     )
     .unwrap();
     let import_map_bytes = Arc::new(content.as_bytes().to_vec());
-    eszip.add_import_map(specifier.to_string(), import_map_bytes);
+    eszip.add_import_map(
+      ModuleKind::Json,
+      specifier.to_string(),
+      import_map_bytes,
+    );
 
     let module = eszip.get_module("file:///import_map.json").unwrap();
     assert_eq!(module.specifier, "file:///import_map.json");
@@ -1265,7 +1269,11 @@ mod tests {
     )
     .unwrap();
     let import_map_bytes = Arc::new(content.as_bytes().to_vec());
-    eszip.add_import_map(specifier.to_string(), import_map_bytes);
+    eszip.add_import_map(
+      ModuleKind::Json,
+      specifier.to_string(),
+      import_map_bytes,
+    );
 
     // Verify that the resulting eszip consists of two unique modules even
     // though `import_map.json` is referenced twice:

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -336,7 +336,7 @@ impl EszipV2 {
     specifier: String,
     source: Arc<Vec<u8>>,
   ) {
-    debug_assert_ne!(kind, ModuleKind::JavaScript);
+    debug_assert!(matches!(kind, ModuleKind::Json | ModuleKind::Jsonc));
 
     let mut modules = self.modules.lock().unwrap();
 

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -330,12 +330,14 @@ impl EszipV2 {
   ///
   /// If a module with this specifier is already present, then this is a no-op
   /// (except that this specifier will now be at the top of the archive).
-  pub fn add_import_map(&mut self, specifier: String, source: Arc<Vec<u8>>) {
-    let module = EszipV2Module::Module {
-      kind: ModuleKind::Json,
-      source: EszipV2SourceSlot::Ready(source),
-      source_map: EszipV2SourceSlot::Ready(Arc::new(vec![])),
-    };
+  pub fn add_import_map(
+    &mut self,
+    kind: ModuleKind,
+    specifier: String,
+    source: Arc<Vec<u8>>,
+  ) {
+    debug_assert_ne!(kind, ModuleKind::JavaScript);
+
     let mut modules = self.modules.lock().unwrap();
 
     // If an entry with the specifier already exists, we just move that to the
@@ -345,7 +347,14 @@ impl EszipV2 {
       return;
     }
 
-    modules.insert(specifier.clone(), module);
+    modules.insert(
+      specifier.clone(),
+      EszipV2Module::Module {
+        kind,
+        source: EszipV2SourceSlot::Ready(source),
+        source_map: EszipV2SourceSlot::Ready(Arc::new(vec![])),
+      },
+    );
     modules.to_front(&specifier);
   }
 

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -37,7 +37,7 @@ enum HeaderFrameKind {
 #[derive(Debug, Default)]
 pub struct EszipV2 {
   modules: Arc<Mutex<HashMap<String, EszipV2Module>>>,
-  pub ordered_modules: Vec<String>,
+  ordered_modules: Vec<String>,
 }
 
 #[derive(Debug)]

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -799,7 +799,9 @@ mod tests {
 
   use crate::ModuleKind;
 
-  struct FileLoader;
+  struct FileLoader {
+    base_dir: String,
+  }
 
   macro_rules! assert_matches_file {
     ($source:ident, $file:literal) => {
@@ -818,7 +820,7 @@ mod tests {
     ) -> deno_graph::source::LoadFuture {
       match specifier.scheme() {
         "file" => {
-          let path = format!("./src/testdata/source{}", specifier.path());
+          let path = format!("{}{}", self.base_dir, specifier.path());
           Box::pin(async move {
             let path = Path::new(&path);
             let Ok(resolved) = path.canonicalize() else {
@@ -927,10 +929,13 @@ mod tests {
     let roots = vec![ModuleSpecifier::parse("file:///main.ts").unwrap()];
     let analyzer = CapturingModuleAnalyzer::default();
     let mut graph = ModuleGraph::default();
+    let mut loader = FileLoader {
+      base_dir: "./src/testdata/source".to_string(),
+    };
     graph
       .build(
         roots,
-        &mut FileLoader,
+        &mut loader,
         BuildOptions {
           module_analyzer: Some(&analyzer),
           ..Default::default()
@@ -965,10 +970,13 @@ mod tests {
     let roots = vec![ModuleSpecifier::parse("file:///json.ts").unwrap()];
     let analyzer = CapturingModuleAnalyzer::default();
     let mut graph = ModuleGraph::default();
+    let mut loader = FileLoader {
+      base_dir: "./src/testdata/source".to_string(),
+    };
     graph
       .build(
         roots,
-        &mut FileLoader,
+        &mut loader,
         BuildOptions {
           module_analyzer: Some(&analyzer),
           ..Default::default()
@@ -1002,10 +1010,13 @@ mod tests {
     let roots = vec![ModuleSpecifier::parse("file:///dynamic.ts").unwrap()];
     let analyzer = CapturingModuleAnalyzer::default();
     let mut graph = ModuleGraph::default();
+    let mut loader = FileLoader {
+      base_dir: "./src/testdata/source".to_string(),
+    };
     graph
       .build(
         roots,
-        &mut FileLoader,
+        &mut loader,
         BuildOptions {
           module_analyzer: Some(&analyzer),
           ..Default::default()
@@ -1038,10 +1049,13 @@ mod tests {
       vec![ModuleSpecifier::parse("file:///dynamic_data.ts").unwrap()];
     let analyzer = CapturingModuleAnalyzer::default();
     let mut graph = ModuleGraph::default();
+    let mut loader = FileLoader {
+      base_dir: "./src/testdata/source".to_string(),
+    };
     graph
       .build(
         roots,
-        &mut FileLoader,
+        &mut loader,
         BuildOptions {
           module_analyzer: Some(&analyzer),
           ..Default::default()
@@ -1152,7 +1166,9 @@ mod tests {
 
   #[tokio::test]
   async fn import_map() {
-    let mut loader = FileLoader;
+    let mut loader = FileLoader {
+      base_dir: "./src/testdata/source".to_string(),
+    };
     let resp = deno_graph::source::Loader::load(
       &mut loader,
       &Url::parse("file:///import_map.json").unwrap(),
@@ -1174,7 +1190,7 @@ mod tests {
     graph
       .build(
         roots,
-        &mut FileLoader,
+        &mut loader,
         BuildOptions {
           resolver: Some(&ImportMapResolver(import_map.import_map)),
           module_analyzer: Some(&analyzer),
@@ -1224,7 +1240,9 @@ mod tests {
   // https://github.com/denoland/eszip/issues/110
   #[tokio::test]
   async fn import_map_imported_from_program() {
-    let mut loader = FileLoader;
+    let mut loader = FileLoader {
+      base_dir: "./src/testdata/source".to_string(),
+    };
     let resp = deno_graph::source::Loader::load(
       &mut loader,
       &Url::parse("file:///import_map.json").unwrap(),
@@ -1248,7 +1266,7 @@ mod tests {
     graph
       .build(
         roots,
-        &mut FileLoader,
+        &mut loader,
         BuildOptions {
           resolver: Some(&ImportMapResolver(import_map.import_map)),
           module_analyzer: Some(&analyzer),

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -598,7 +598,11 @@ impl EszipV2 {
 
   /// Get the module metadata for a given module specifier. This function will
   /// follow redirects. The returned module has functions that can be used to
-  /// obtain the module source and source map.
+  /// obtain the module source and source map. The module returned from this
+  /// function is guaranteed to be a valid module, which can be loaded into v8.
+  ///
+  /// Note that this function should be used to obtain a module; if you wish to
+  /// get an import map, use [`get_import_map`](Self::get_import_map) instead.
   pub fn get_module(&self, specifier: &str) -> Option<Module> {
     let module = self.lookup(specifier)?;
 
@@ -611,6 +615,12 @@ impl EszipV2 {
     Some(module)
   }
 
+  /// Get the import map for a given specifier.
+  ///
+  /// Note that this function should be used to obtain an import map; the returned
+  /// "Module" is not necessarily a valid module that can be loaded into v8 (in
+  /// other words, JSONC may be returned). If you wish to get a valid module,
+  /// use [`get_module`](Self::get_module) instead.
   pub fn get_import_map(&self, specifier: &str) -> Option<Module> {
     let import_map = self.lookup(specifier)?;
 

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -603,7 +603,7 @@ impl EszipV2 {
     let module = self.lookup(specifier)?;
 
     // JSONC is contained in this eszip only for use as an import map. In
-    // order for the caller to get this JSONS, call `get_import_map` instead.
+    // order for the caller to get this JSONC, call `get_import_map` instead.
     if module.kind == ModuleKind::Jsonc {
       return None;
     }
@@ -632,7 +632,7 @@ impl EszipV2 {
       let module = modules.get(specifier)?;
       match module {
         // JSONC is contained in this eszip only for use as an import map. In
-        // order for the caller to get this JSONS, call `get_import_map` instead.
+        // order for the caller to get this JSONC, call `get_import_map` instead.
         EszipV2Module::Module { kind, .. } if *kind == ModuleKind::Jsonc => {
           return None;
         }

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -631,11 +631,6 @@ impl EszipV2 {
       visited.insert(specifier);
       let module = modules.get(specifier)?;
       match module {
-        // JSONC is contained in this eszip only for use as an import map. In
-        // order for the caller to get this JSONC, call `get_import_map` instead.
-        EszipV2Module::Module { kind, .. } if *kind == ModuleKind::Jsonc => {
-          return None;
-        }
         EszipV2Module::Module { kind, .. } => {
           return Some(Module {
             specifier: specifier.to_string(),

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -336,6 +336,14 @@ impl EszipV2 {
       source_map: EszipV2SourceSlot::Ready(Arc::new(vec![])),
     };
     let mut modules = self.modules.lock().unwrap();
+
+    // If an entry with the specifier already exists, we just move that to the
+    // top and return without inserting new source.
+    if modules.contains_key(&specifier) {
+      modules.to_front(&specifier);
+      return;
+    }
+
     modules.insert(specifier.clone(), module);
     modules.to_front(&specifier);
   }

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -526,7 +526,7 @@ impl EszipV2 {
             source: EszipV2SourceSlot::Ready(Arc::new(source)),
             source_map: EszipV2SourceSlot::Ready(Arc::new(source_map)),
           };
-          modules.insert(specifier.clone(), eszip_module);
+          modules.insert(specifier, eszip_module);
 
           // now walk the code dependencies
           for dep in module.dependencies.values() {
@@ -553,7 +553,7 @@ impl EszipV2 {
             )),
             source_map: EszipV2SourceSlot::Ready(Arc::new(vec![])),
           };
-          modules.insert(specifier.clone(), eszip_module);
+          modules.insert(specifier, eszip_module);
           Ok(())
         }
         deno_graph::Module::External(_)


### PR DESCRIPTION
This commit allows JSONC to be embedded in an eszip as an import map. This is primarily for deno's config file, which can be JSONC (e.g. `deno.jsonc`).

Embedded JSONC data can then be retrieved by calling `get_import_map` method, which is a new method. Keep in mind that the existing similar method, `get_module`, will not return JSONC. This separation ensures that whatever returned from `get_module` is definitely a valid module, which may be useful when implementing support for dynamic import.

Ideally eszip's serialization format should have a dedicated optional section for an import map so that we can treat import maps and modules differently. We can't do this while keeping v2 since this would break backward compatibility.

ref https://github.com/denoland/deploy_feedback/issues/344
ref https://github.com/denoland/fresh/pull/1188
