### PR TITLE
chore: use Arc<[u8]> instead of Arc<Vec<u8>>

### DIFF
--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -311,7 +311,7 @@ pub async fn build_eszip(
     eszip.add_import_map(
       ModuleKind::Json,
       import_map_specifier.to_string(),
-      Arc::new(import_map_content.as_bytes().to_vec()),
+      Arc::from(import_map_content),
     )
   }
   Ok(Uint8Array::from(eszip.into_bytes().as_slice()))

--- a/src/examples/builder.rs
+++ b/src/examples/builder.rs
@@ -69,7 +69,7 @@ async fn main() {
     eszip.add_import_map(
       eszip::ModuleKind::Json,
       import_map_specifier.to_string(),
-      Arc::new(import_map_content.as_bytes().to_vec()),
+      Arc::from(import_map_content),
     )
   }
   for specifier in eszip.specifiers() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ pub enum ModuleInner {
 
 impl Module {
   /// Get source code of the module.
-  pub async fn source(&self) -> Option<Arc<Vec<u8>>> {
+  pub async fn source(&self) -> Option<Arc<[u8]>> {
     match &self.inner {
       ModuleInner::V1(eszip_v1) => eszip_v1.get_module_source(&self.specifier),
       ModuleInner::V2(eszip_v2) => {
@@ -116,7 +116,7 @@ impl Module {
   /// the subsequent calls to `take_source()` will return `None`.
   /// For V1, this will take the entire module and returns the source code. We don't need
   /// to preserve module metadata for V1.
-  pub async fn take_source(&self) -> Option<Arc<Vec<u8>>> {
+  pub async fn take_source(&self) -> Option<Arc<[u8]>> {
     match &self.inner {
       ModuleInner::V1(eszip_v1) => eszip_v1.take(&self.specifier),
       ModuleInner::V2(eszip_v2) => {
@@ -126,7 +126,7 @@ impl Module {
   }
 
   /// Get source map of the module.
-  pub async fn source_map(&self) -> Option<Arc<Vec<u8>>> {
+  pub async fn source_map(&self) -> Option<Arc<[u8]>> {
     match &self.inner {
       ModuleInner::V1(_) => None,
       ModuleInner::V2(eszip) => {
@@ -137,7 +137,7 @@ impl Module {
 
   /// Take source map of the module. This will remove the source map from memory and
   /// the subsequent calls to `take_source_map()` will return `None`.
-  pub async fn take_source_map(&self) -> Option<Arc<Vec<u8>>> {
+  pub async fn take_source_map(&self) -> Option<Arc<[u8]>> {
     match &self.inner {
       ModuleInner::V1(_) => None,
       ModuleInner::V2(eszip) => {


### PR DESCRIPTION
This removes a double boxing, and allows zero-copy loading into
deno_core through `FastString::Arc`.
