### PR TITLE
feat: implement `IntoIterator` for `Eszip` and `EszipV1`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.71.1"
+channel = "1.75.0"
 components = ["clippy", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.71.1"
 components = ["clippy", "rustfmt"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ type EszipParserOutput<R> = Result<futures::io::BufReader<R>, ParseError>;
 /// This future needs to polled to parse the eszip file.
 type EszipParserFuture<R> = BoxFuture<'static, EszipParserOutput<R>>;
 /// This future needs to polled to parse the eszip file.
-type EszipParserLoalFuture<R> = LocalBoxFuture<'static, EszipParserOutput<R>>;
+type EszipParserLocalFuture<R> = LocalBoxFuture<'static, EszipParserOutput<R>>;
 
 impl Eszip {
   /// Parse a byte stream into an Eszip. This function completes when the header
@@ -66,7 +66,7 @@ impl Eszip {
   /// returned future does not implement `Send` either.
   pub async fn parse_local<R: futures::io::AsyncRead + Unpin + 'static>(
     reader: R,
-  ) -> Result<(Eszip, EszipParserLoalFuture<R>), ParseError> {
+  ) -> Result<(Eszip, EszipParserLocalFuture<R>), ParseError> {
     let mut reader = futures::io::BufReader::new(reader);
     reader.fill_buf().await?;
     let buffer = reader.buffer();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,24 @@ impl Eszip {
   }
 }
 
+/// Get an iterator over all the modules (including an import map, if any) in
+/// this eszip archive.
+///
+/// Note that the iterator will iterate over the specifiers' "snapshot" of the
+/// archive. If a new module is added to the archive after the iterator is
+/// created via `into_iter()`, that module will not be iterated over.
+impl IntoIterator for Eszip {
+  type Item = (String, Module);
+  type IntoIter = std::vec::IntoIter<Self::Item>;
+
+  fn into_iter(self) -> Self::IntoIter {
+    match self {
+      Eszip::V1(eszip) => eszip.into_iter(),
+      Eszip::V2(eszip) => eszip.into_iter(),
+    }
+  }
+}
+
 pub struct Module {
   pub specifier: String,
   pub kind: ModuleKind,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,15 +28,18 @@ pub enum Eszip {
 }
 
 /// This future needs to polled to parse the eszip file.
-type EszipParserFuture<R> =
-  Pin<Box<dyn Future<Output = Result<futures::io::BufReader<R>, ParseError>>>>;
+type EszipParserFuture<R> = Pin<
+  Box<
+    dyn Future<Output = Result<futures::io::BufReader<R>, ParseError>> + Send,
+  >,
+>;
 
 impl Eszip {
   /// Parse a byte stream into an Eszip. This function completes when the header
   /// is fully received. This does not mean that the entire file is fully
   /// received or parsed yet. To finish parsing, the future returned by this
   /// function in the second tuple slot needs to be polled.
-  pub async fn parse<R: futures::io::AsyncRead + Unpin + 'static>(
+  pub async fn parse<R: futures::io::AsyncRead + Unpin + Send + 'static>(
     reader: R,
   ) -> Result<(Eszip, EszipParserFuture<R>), ParseError> {
     let mut reader = futures::io::BufReader::new(reader);

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -217,12 +217,12 @@ impl EszipV2 {
   /// header section of the eszip has been parsed. Once this function returns,
   /// the data section will not necessarially have been parsed yet. To parse
   /// the data section, poll/await the future returned in the second tuple slot.
-  pub async fn parse<R: futures::io::AsyncRead + Unpin + Send>(
+  pub async fn parse<R: futures::io::AsyncRead + Unpin>(
     mut reader: futures::io::BufReader<R>,
   ) -> Result<
     (
       EszipV2,
-      impl Future<Output = Result<futures::io::BufReader<R>, ParseError>> + Send,
+      impl Future<Output = Result<futures::io::BufReader<R>, ParseError>>,
     ),
     ParseError,
   > {

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -217,12 +217,12 @@ impl EszipV2 {
   /// header section of the eszip has been parsed. Once this function returns,
   /// the data section will not necessarially have been parsed yet. To parse
   /// the data section, poll/await the future returned in the second tuple slot.
-  pub async fn parse<R: futures::io::AsyncRead + Unpin>(
+  pub async fn parse<R: futures::io::AsyncRead + Unpin + Send>(
     mut reader: futures::io::BufReader<R>,
   ) -> Result<
     (
       EszipV2,
-      impl Future<Output = Result<futures::io::BufReader<R>, ParseError>>,
+      impl Future<Output = Result<futures::io::BufReader<R>, ParseError>> + Send,
     ),
     ParseError,
   > {

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -90,10 +90,14 @@ impl EszipV2Modules {
           wakers.push(cx.waker().clone());
           return Poll::Pending;
         }
-        EszipV2SourceSlot::Ready(_) => {},
+        EszipV2SourceSlot::Ready(_) => {}
         EszipV2SourceSlot::Taken => return Poll::Ready(None),
       };
-      let EszipV2SourceSlot::Ready(bytes) = std::mem::replace(slot, EszipV2SourceSlot::Taken) else { unreachable!() };
+      let EszipV2SourceSlot::Ready(bytes) =
+        std::mem::replace(slot, EszipV2SourceSlot::Taken)
+      else {
+        unreachable!()
+      };
       Poll::Ready(Some(bytes))
     })
     .await


### PR DESCRIPTION
This adds implementation of `IntoIterator` trait for `Eszip` and `EszipV1`. This will help us iterate over all the modules included in an eszip archive.

Note that we have already `IntoIterator` implemented for `EszipV2`.