### PR TITLE
feat: `from_graph` - ability to make file specifiers relative

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ast"
-version = "0.39.0"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32edef567e3090862e865c75628f4d35ace80ca90e0fc5263a7d10fa307ae899"
+checksum = "132aace7b62c317da51f84f1cfbbbfc56ce643110821937c04b36c916db64341"
 dependencies = [
  "anyhow",
  "base64",
@@ -463,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.78.0"
+version = "0.79.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ccd2755a805983f96aeccd211c1f7585b6bfec77471f502c47227abe375682"
+checksum = "caa95531b3eb65aced626d8dd8117b29b3e57763e0c1ace502101fb56b8a2c31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1019,9 +1019,9 @@ checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "import_map"
-version = "0.19.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72395c7d41857a714b5ce1266685ef3c5ceb761ce601a99c44c072d72b41a1e3"
+checksum = "373b8288ad259df0d1314e3e8b2fff0e5e63f22e01bc54ecd2c3c7ad77b9200c"
 dependencies = [
  "indexmap",
  "log",
@@ -2054,9 +2054,9 @@ dependencies = [
 
 [[package]]
 name = "swc_config"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be1a689e146be1eae53139482cb061dcf0fa01dff296bbe7b96fff92d8e2936"
+checksum = "84b67e115ab136fe0eb03558bb0508ca7782eeb446a96d165508c48617e3fd94"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2080,9 +2080,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.113.4"
+version = "0.113.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1690cc0c9ab60b44ac0225ba1e231ac532f7ba1d754df761c6ee607561afae"
+checksum = "98a534a8360a076a030989f6d121ba6044345594bdf0457c4629f432742026b8"
 dependencies = [
  "bitflags 2.5.0",
  "is-macro",
@@ -2098,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.149.1"
+version = "0.149.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fef147127a2926ca26171c7afcbf028ff86dc543ced87d316713f25620a15b9"
+checksum = "efb2bef3f4998865b2d466fb2ef9410a03449d255d199f3eb807fb19acc3862b"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -2143,9 +2143,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.144.1"
+version = "0.144.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0499e69683ae5d67a20ff0279b94bc90f29df7922a46331b54d5dd367bf89570"
+checksum = "fc0b4193b9c127db1990a5a08111aafe0122bc8b138646807c63f2a6521b7da4"
 dependencies = [
  "either",
  "new_debug_unreachable",
@@ -2165,9 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.138.2"
+version = "0.138.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddb95c2bdad1c9c29edf35712e1e0f9b9ddc1cdb5ba2d582fd93468cb075a03"
+checksum = "f7b76d09313cdd8f99bc1519fb04f8a93427c7a6f4bfbc64b39fcc5a378ab1b7"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.5.0",
@@ -2275,14 +2275,15 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.128.1"
+version = "0.128.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5242670bc74e0a0b64b9d4912b37be36944517ce0881314162aeb4381272c3"
+checksum = "02f470d8cc31adf6189b228636201ee3cdd268c0b5a2d0407f83093dfa96ff91"
 dependencies = [
  "indexmap",
  "num_cpus",
  "once_cell",
  "rustc-hash",
+ "ryu-js",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ license = "MIT"
 members = ["lib"]
 
 [workspace.dependencies]
-deno_graph = "0.78.0"
-import_map = "0.19.1"
+deno_graph = "0.79.0"
+import_map = "0.20.0"
 serde = "1"
 
 [profile.release]

--- a/benches/source_hash_function.rs
+++ b/benches/source_hash_function.rs
@@ -177,12 +177,13 @@ async fn build_eszip(mb: usize) -> EszipV2 {
     )
     .await;
   graph.valid().unwrap();
-  EszipV2::from_graph(
+  EszipV2::from_graph(eszip::FromGraphOptions {
     graph,
-    &analyzer.as_capturing_parser(),
-    TranspileOptions::default(),
-    EmitOptions::default(),
-  )
+    parser: analyzer.as_capturing_parser(),
+    transpile_options: TranspileOptions::default(),
+    emit_options: EmitOptions::default(),
+    relative_file_base: None,
+  })
   .unwrap()
 }
 

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -298,7 +298,7 @@ pub async fn build_eszip(
         specifier, content, ..
       } => {
         let import_map = import_map::parse_from_json_with_options(
-          &specifier,
+          specifier.clone(),
           &String::from_utf8(content.to_vec()).unwrap(),
           import_map::ImportMapOptions {
             address_hook: None,
@@ -340,12 +340,13 @@ pub async fn build_eszip(
   graph
     .valid()
     .map_err(|e| js_sys::Error::new(&e.to_string()))?;
-  let mut eszip = eszip::EszipV2::from_graph(
+  let mut eszip = eszip::EszipV2::from_graph(eszip::FromGraphOptions {
     graph,
-    &analyzer.as_capturing_parser(),
-    Default::default(),
-    Default::default(),
-  )
+    parser: analyzer.as_capturing_parser(),
+    transpile_options: Default::default(),
+    emit_options: Default::default(),
+    relative_file_base: None,
+  })
   .map_err(|e| js_sys::Error::new(&e.to_string()))?;
   if let Some((import_map_specifier, import_map_content)) =
     maybe_import_map_data

--- a/src/examples/builder.rs
+++ b/src/examples/builder.rs
@@ -44,7 +44,7 @@ async fn main() {
         } => {
           let content = String::from_utf8(content.to_vec()).unwrap();
           let import_map =
-            import_map::parse_from_json(&specifier, &content).unwrap();
+            import_map::parse_from_json(specifier.clone(), &content).unwrap();
           (Some(import_map.import_map), Some((specifier, content)))
         }
         _ => unimplemented!(),
@@ -70,12 +70,13 @@ async fn main() {
 
   graph.valid().unwrap();
 
-  let mut eszip = eszip::EszipV2::from_graph(
+  let mut eszip = eszip::EszipV2::from_graph(eszip::FromGraphOptions {
     graph,
-    &analyzer.as_capturing_parser(),
-    TranspileOptions::default(),
-    EmitOptions::default(),
-  )
+    parser: analyzer.as_capturing_parser(),
+    transpile_options: TranspileOptions::default(),
+    emit_options: EmitOptions::default(),
+    relative_file_base: None,
+  })
   .unwrap();
   if let Some((import_map_specifier, import_map_content)) =
     maybe_import_map_data

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ use v2::EszipV2Modules;
 pub use crate::error::ParseError;
 pub use crate::v1::EszipV1;
 pub use crate::v2::EszipV2;
+pub use crate::v2::FromGraphOptions;
 
 pub use deno_ast;
 pub use deno_graph;


### PR DESCRIPTION
This is for `deno compile`.

1. It allows us to not mix windows paths on linux and vice versa.
1. We won't be storing the build machine's folder path in the binary anymore.
1. It makes workspace support easier to implement because I can lay out the files in the eszip in the same directory as the node_modules folder. It's not really easy to do this otherwise.

That said, there is a drawbacks that if someone is using an absolute file path in an import specifier then it will no longer work if the path is within the folder to make everything relative to.

Let me know if you think of a better solution, but I feel like this is reasonable?